### PR TITLE
Update Polyhedra notebook

### DIFF
--- a/Polyhedra.ipynb
+++ b/Polyhedra.ipynb
@@ -61,20 +61,18 @@
     {
      "data": {
       "text/plain": [
-       "CDDLib.CDDPolyhedron{6,Rational{BigInt}}(Nullable{CDDLib.CDDInequalityMatrix{6,Rational{BigInt},S} where S<:Union{CDDLib.GMPRational, Float64}}(H-representation\n",
-       "begin\n",
-       " 10 7 rational\n",
-       " 0//1 0//1 0//1 0//1 1//1 0//1 0//1\n",
-       " 0//1 0//1 0//1 0//1 0//1 1//1 0//1\n",
-       " 0//1 0//1 0//1 0//1 0//1 0//1 1//1\n",
-       " 0//1 -1//1 0//1 0//1 1//1 0//1 0//1\n",
-       " 0//1 0//1 -1//1 0//1 0//1 1//1 0//1\n",
-       " 0//1 0//1 0//1 -1//1 0//1 0//1 1//1\n",
-       " 0//1 1//1 0//1 0//1 1//1 0//1 0//1\n",
-       " 0//1 0//1 1//1 0//1 0//1 1//1 0//1\n",
-       " 0//1 0//1 0//1 1//1 0//1 0//1 1//1\n",
-       " 1//1 0//1 0//1 0//1 -1//1 -1//1 -1//1\n",
-       "end), Nullable{CDDLib.CDDGeneratorMatrix{6,Rational{BigInt},S} where S<:Union{CDDLib.GMPRational, Float64}}(), Nullable{CDDLib.CDDPolyhedra{6,Rational{BigInt},S} where S}(), false, false, false, false)"
+       "Polyhedron CDDLib.CDDPolyhedron{6,Rational{BigInt}}:\n",
+       "10-element iterator of Polyhedra.HalfSpace{6,Rational{BigInt},Array{Rational{BigInt},1}}:\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, 0//1, -1//1, 0//1, 0//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, 0//1, 0//1, -1//1, 0//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, 0//1, 0//1, 0//1, -1//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, 0//1, 0//1, -1//1, 0//1, 0//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 1//1, 0//1, 0//1, -1//1, 0//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, 1//1, 0//1, 0//1, -1//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 0//1, 0//1, -1//1, 0//1, 0//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, -1//1, 0//1, 0//1, -1//1, 0//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, -1//1, 0//1, 0//1, -1//1], 0//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, 0//1, 1//1, 1//1, 1//1], 1//1)"
       ]
      },
      "execution_count": 3,
@@ -94,37 +92,35 @@
     {
      "data": {
       "text/plain": [
-       "CDDLib.CDDPolyhedron{3,Rational{BigInt}}(Nullable{CDDLib.CDDInequalityMatrix{3,Rational{BigInt},S} where S<:Union{CDDLib.GMPRational, Float64}}(H-representation\n",
-       "begin\n",
-       " 27 4 rational\n",
-       " 1//1 0//1 1//1 1//1\n",
-       " 1//1 0//1 1//1 -1//1\n",
-       " 1//1 0//1 -1//1 1//1\n",
-       " 1//1 0//1 -1//1 -1//1\n",
-       " 1//1 0//1 1//1 0//1\n",
-       " 1//1 0//1 -1//1 0//1\n",
-       " 1//1 0//1 0//1 0//1\n",
-       " 1//1 0//1 0//1 -1//1\n",
-       " 1//1 0//1 0//1 1//1\n",
-       " 1//1 -1//1 0//1 0//1\n",
-       " 1//1 1//1 0//1 0//1\n",
-       " 1//1 -1//1 0//1 -1//1\n",
-       " 1//1 -1//1 0//1 1//1\n",
-       " 1//1 1//1 0//1 -1//1\n",
-       " 1//1 1//1 0//1 1//1\n",
-       " 1//1 -1//1 -1//1 0//1\n",
-       " 1//1 -1//1 1//1 0//1\n",
-       " 1//1 -1//1 -1//1 -1//1\n",
-       " 1//1 -1//1 -1//1 1//1\n",
-       " 1//1 -1//1 1//1 -1//1\n",
-       " 1//1 -1//1 1//1 1//1\n",
-       " 1//1 1//1 -1//1 0//1\n",
-       " 1//1 1//1 1//1 0//1\n",
-       " 1//1 1//1 -1//1 -1//1\n",
-       " 1//1 1//1 -1//1 1//1\n",
-       " 1//1 1//1 1//1 -1//1\n",
-       " 1//1 1//1 1//1 1//1\n",
-       "end), Nullable{CDDLib.CDDGeneratorMatrix{3,Rational{BigInt},S} where S<:Union{CDDLib.GMPRational, Float64}}(), Nullable{CDDLib.CDDPolyhedra{3,Rational{BigInt},S} where S}(), false, false, false, false)"
+       "H-representation CDDLib.CDDInequalityMatrix{3,Rational{BigInt},CDDLib.GMPRational}:\n",
+       "27-element iterator of Polyhedra.HalfSpace{3,Rational{BigInt},Array{Rational{BigInt},1}}:\n",
+       " HalfSpace(Rational{BigInt}[0//1, -1//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, -1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 1//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, -1//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 1//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[0//1, 0//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, 0//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 0//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, 0//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, 0//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 0//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 0//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, 1//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, -1//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, 1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, 1//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, -1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, -1//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 1//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, -1//1, 0//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 1//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, -1//1, 1//1], 1//1)\n",
+       "  ⋮"
       ]
      },
      "execution_count": 4,
@@ -133,7 +129,8 @@
     }
    ],
    "source": [
-    "poly_x = eliminate(poly, n+1:2n)"
+    "poly_x = eliminate(poly, n+1:2n)\n",
+    "hrep(poly_x)"
    ]
   },
   {
@@ -142,59 +139,28 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SimpleHRepresentation(poly_x) = H-representation\n",
-      "begin\n",
-      " 27 4 rational\n",
-      " 1//1 0//1 1//1 1//1\n",
-      " 1//1 0//1 1//1 -1//1\n",
-      " 1//1 0//1 -1//1 1//1\n",
-      " 1//1 0//1 -1//1 -1//1\n",
-      " 1//1 0//1 1//1 0//1\n",
-      " 1//1 0//1 -1//1 0//1\n",
-      " 1//1 0//1 0//1 0//1\n",
-      " 1//1 0//1 0//1 -1//1\n",
-      " 1//1 0//1 0//1 1//1\n",
-      " 1//1 -1//1 0//1 0//1\n",
-      " 1//1 1//1 0//1 0//1\n",
-      " 1//1 -1//1 0//1 -1//1\n",
-      " 1//1 -1//1 0//1 1//1\n",
-      " 1//1 1//1 0//1 -1//1\n",
-      " 1//1 1//1 0//1 1//1\n",
-      " 1//1 -1//1 -1//1 0//1\n",
-      " 1//1 -1//1 1//1 0//1\n",
-      " 1//1 -1//1 -1//1 -1//1\n",
-      " 1//1 -1//1 -1//1 1//1\n",
-      " 1//1 -1//1 1//1 -1//1\n",
-      " 1//1 -1//1 1//1 1//1\n",
-      " 1//1 1//1 -1//1 0//1\n",
-      " 1//1 1//1 1//1 0//1\n",
-      " 1//1 1//1 -1//1 -1//1\n",
-      " 1//1 1//1 -1//1 1//1\n",
-      " 1//1 1//1 1//1 -1//1\n",
-      " 1//1 1//1 1//1 1//1\n",
-      "end\n",
-      "SimpleHRepresentation(poly_x) = H-representation\n",
-      "begin\n",
-      " 8 4 rational\n",
-      " 1//1 -1//1 -1//1 -1//1\n",
-      " 1//1 -1//1 -1//1 1//1\n",
-      " 1//1 -1//1 1//1 -1//1\n",
-      " 1//1 -1//1 1//1 1//1\n",
-      " 1//1 1//1 -1//1 -1//1\n",
-      " 1//1 1//1 -1//1 1//1\n",
-      " 1//1 1//1 1//1 -1//1\n",
-      " 1//1 1//1 1//1 1//1\n",
-      "end\n"
-     ]
+     "data": {
+      "text/plain": [
+       "H-representation CDDLib.CDDInequalityMatrix{3,Rational{BigInt},CDDLib.GMPRational}:\n",
+       "8-element iterator of Polyhedra.HalfSpace{3,Rational{BigInt},Array{Rational{BigInt},1}}:\n",
+       " HalfSpace(Rational{BigInt}[1//1, 1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, 1//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, -1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[1//1, -1//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, 1//1, -1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, -1//1, 1//1], 1//1)\n",
+       " HalfSpace(Rational{BigInt}[-1//1, -1//1, -1//1], 1//1)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "@show SimpleHRepresentation(poly_x)\n",
     "removehredundancy!(poly_x)\n",
-    "@show SimpleHRepresentation(poly_x);"
+    "hrep(poly_x)"
    ]
   },
   {
@@ -203,42 +169,61 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SimpleVRepresentation(poly_x) = V-representation\n",
-      "begin\n",
-      " 6 4 rational\n",
-      " 1 0//1 0//1 1//1\n",
-      " 1 1//1 0//1 0//1\n",
-      " 1 0//1 1//1 0//1\n",
-      " 1 0//1 0//1 -1//1\n",
-      " 1 0//1 -1//1 0//1\n",
-      " 1 -1//1 0//1 0//1\n",
-      "end\n",
-      "SimpleVRepresentation(poly_x) = V-representation\n",
-      "begin\n",
-      " 6 4 rational\n",
-      " 1 0//1 0//1 1//1\n",
-      " 1 1//1 0//1 0//1\n",
-      " 1 0//1 1//1 0//1\n",
-      " 1 0//1 0//1 -1//1\n",
-      " 1 0//1 -1//1 0//1\n",
-      " 1 -1//1 0//1 0//1\n",
-      "end\n"
-     ]
+     "data": {
+      "text/plain": [
+       "V-representation CDDLib.CDDGeneratorMatrix{3,Rational{BigInt},CDDLib.GMPRational}:\n",
+       "6-element iterator of Array{Rational{BigInt},1}:\n",
+       " Rational{BigInt}[0//1, 0//1, 1//1]\n",
+       " Rational{BigInt}[1//1, 0//1, 0//1]\n",
+       " Rational{BigInt}[0//1, 1//1, 0//1]\n",
+       " Rational{BigInt}[0//1, 0//1, -1//1]\n",
+       " Rational{BigInt}[0//1, -1//1, 0//1]\n",
+       " Rational{BigInt}[-1//1, 0//1, 0//1]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "@show SimpleVRepresentation(poly_x)\n",
+    "vrep(poly_x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "V-representation CDDLib.CDDGeneratorMatrix{3,Rational{BigInt},CDDLib.GMPRational}:\n",
+       "6-element iterator of Array{Rational{BigInt},1}:\n",
+       " Rational{BigInt}[0//1, 0//1, 1//1]\n",
+       " Rational{BigInt}[1//1, 0//1, 0//1]\n",
+       " Rational{BigInt}[0//1, 1//1, 0//1]\n",
+       " Rational{BigInt}[0//1, 0//1, -1//1]\n",
+       " Rational{BigInt}[0//1, -1//1, 0//1]\n",
+       " Rational{BigInt}[-1//1, 0//1, 0//1]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "removevredundancy!(poly_x)\n",
-    "@show SimpleVRepresentation(poly_x);"
+    "vrep(poly_x)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
Polyhedra now has a new output which should hopefully be clearer. This PR updates the outputs accordingly.
Moreover, the printing is now different depending on the MIME so
```julia
julia> show(HyperPlane([1, 0], 0) ∩ HyperPlane([0, 1], 0));
HyperPlane([1, 0], 0) ∩ HyperPlane([0, 1], 0)
julia> HyperPlane([1, 0], 0) ∩ HyperPlane([0, 1], 0)
H-representation Polyhedra.HyperPlanesIntersection{2,Int64,Array{Int64,1}}:
2-element iterator of Polyhedra.HyperPlane{2,Int64,Array{Int64,1}}:
 HyperPlane([1, 0], 0)
 HyperPlane([0, 1], 0)
```
For this reason, the PR splits some cells instead of showing the output with `@show`